### PR TITLE
small typo in POD (bootstap -> bootstrap)

### DIFF
--- a/lib/Dist/Zilla/Role/Bootstrap.pm
+++ b/lib/Dist/Zilla/Role/Bootstrap.pm
@@ -271,9 +271,9 @@ Implementation is quite simple:
     my ( $self ) = @_;
   }
 
-=item 3. I<Optional>: Fetch the discovered C<bootstap> root via:
+=item 3. I<Optional>: Fetch the discovered C<bootstrap> root via:
 
-  $self->_bootstap_root
+  $self->_bootstrap_root
 
 =item 4. I<Optional>: Load some path into C<@INC> via:
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Dist-Zilla-Role-Bootstrap.
We thought you might be interested in it too.

    Description: small typo in POD (bootstap -> bootstrap)
    Author: Damyan Ivanov <dmn@debian.org>
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libdist-zilla-role-bootstrap-perl.git/plain/debian/patches/pod-spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
